### PR TITLE
fix: highlight aliased, heading & block links in backlinks view

### DIFF
--- a/src/ui/solid/render-context-tree.tsx
+++ b/src/ui/solid/render-context-tree.tsx
@@ -23,8 +23,8 @@ export function renderContextTree({
   // Extract alias from aliased links ([[Note title|Alias]]) to be highlighted
   highlights = highlights.map((hl) => hl.split('|').slice(-1)[0]);
 
-  // Extract note title from heading and block links
-  highlights = highlights.map((hl) => hl.split('#')[0]);
+  // Reformat heading and block links (e.g. [[Note title#Heading]]) to match reading view
+  highlights = highlights.map((hl) => hl.replace('#', ' > '));
 
   return render(
     () => (

--- a/src/ui/solid/render-context-tree.tsx
+++ b/src/ui/solid/render-context-tree.tsx
@@ -19,6 +19,10 @@ export function renderContextTree({
   highlights,
   infinityScroll
 }: RenderContextTreeProps) {
+
+  // Extract alias from aliased links ([[Note title|Alias]]) to be highlighted
+  highlights = highlights.map((hl) => hl.split('|').slice(-1)[0]);
+
   return render(
     () => (
       <PluginContextProvider plugin={plugin} infinityScroll={infinityScroll}>

--- a/src/ui/solid/render-context-tree.tsx
+++ b/src/ui/solid/render-context-tree.tsx
@@ -23,6 +23,9 @@ export function renderContextTree({
   // Extract alias from aliased links ([[Note title|Alias]]) to be highlighted
   highlights = highlights.map((hl) => hl.split('|').slice(-1)[0]);
 
+  // Extract note title from heading and block links
+  highlights = highlights.map((hl) => hl.split('#')[0]);
+
   return render(
     () => (
       <PluginContextProvider plugin={plugin} infinityScroll={infinityScroll}>


### PR DESCRIPTION
After this fix, the following are also highlighted in the backlinks view:

- aliased links: `[[Title|Alias]]`
- heading links: `[[Title#Heading]]`
- block links: `[[Title#^abcdef]]`

Thanks for the plugin!

Result:

![better-search-views-fix-highlights](https://github.com/user-attachments/assets/523ccae9-f993-4df7-98f8-7da4723cc276)

