### PR TITLE
Fix: page preview highlighting compatibility with Hover Editor

### DIFF
--- a/src/context-tree/create/create-context-tree.ts
+++ b/src/context-tree/create/create-context-tree.ts
@@ -57,7 +57,7 @@ export function createContextTree({
 
     for (const headingCache of headingBreadcrumbs) {
       const headingFoundInChildren = context.branches.find((tree) =>
-        isSamePosition(tree.cacheItem.position, headingCache.position),
+        isSamePosition(tree.cacheItem.position, headingCache.position)
       );
 
       if (headingFoundInChildren) {
@@ -68,7 +68,7 @@ export function createContextTree({
           headingCache,
           stat,
           filePath,
-          headingCache.heading,
+          headingCache.heading
         );
 
         context.branches.push(newContext);
@@ -78,7 +78,7 @@ export function createContextTree({
 
     for (const listItemCache of listBreadcrumbs) {
       const listItemFoundInChildren = context.branches.find((tree) =>
-        isSamePosition(tree.cacheItem.position, listItemCache.position),
+        isSamePosition(tree.cacheItem.position, listItemCache.position)
       );
 
       if (listItemFoundInChildren) {
@@ -89,7 +89,7 @@ export function createContextTree({
           listItemCache,
           stat,
           filePath,
-          getTextAtPosition(fileContents, listItemCache.position),
+          getTextAtPosition(fileContents, listItemCache.position)
         );
 
         context.branches.push(newListContext);
@@ -100,7 +100,7 @@ export function createContextTree({
     // todo: move to metadata-cache-util
     const headingIndexAtPosition = getHeadingIndexContaining(
       position.position,
-      headings,
+      headings
     );
     const linkIsInsideHeading = headingIndexAtPosition >= 0;
 
@@ -109,15 +109,15 @@ export function createContextTree({
 
       const indexOfListItemContainingLink = getListItemIndexContaining(
         position.position,
-        listItems,
+        listItems
       );
       const listItemCacheWithDescendants = getListItemWithDescendants(
         indexOfListItemContainingLink,
-        listItems,
+        listItems
       );
       const text = formatListWithDescendants(
         fileContents,
-        listItemCacheWithDescendants,
+        listItemCacheWithDescendants
       );
 
       context.sectionsWithMatches.push({
@@ -130,7 +130,7 @@ export function createContextTree({
     } else if (linkIsInsideHeading) {
       const firstSectionUnderHeading = getFirstSectionUnder(
         position.position,
-        sections,
+        sections
       );
 
       if (firstSectionUnderHeading) {
@@ -138,7 +138,7 @@ export function createContextTree({
           cache: firstSectionUnderHeading,
           text: getTextAtPosition(
             fileContents,
-            firstSectionUnderHeading.position,
+            firstSectionUnderHeading.position
           ),
           filePath,
         });
@@ -146,7 +146,7 @@ export function createContextTree({
     } else {
       const sectionText = getTextAtPosition(
         fileContents,
-        sectionCache.position,
+        sectionCache.position
       );
       context.sectionsWithMatches.push({
         cache: sectionCache,
@@ -164,7 +164,7 @@ function createContextTreeBranch(
   cacheItem: CacheItem,
   stat: FileStats,
   filePath: string,
-  text: string,
+  text: string
 ) {
   return {
     type,

--- a/src/patcher.ts
+++ b/src/patcher.ts
@@ -224,6 +224,30 @@ export class Patcher {
 
     this.disposerRegistry.addOnEmptyResultsCallback(dispose);
 
-    match.el = mountPoint;
+    // Instead of replacing match.el entirely, we preserve the original element
+    // and append our custom content to it. This is important because Obsidian
+    // adds the "Link" button for unlinked mentions to match.el on hover.
+    // If we replace match.el, Obsidian can no longer find the element to add
+    // the button to.
+    
+    // Clear existing content from match.el while preserving the element itself
+    // We need to preserve any buttons that Obsidian might have already added
+    const existingLinkButton = match.el.querySelector('.search-result-file-match-replace-button');
+    const existingHoverButtons = match.el.querySelectorAll('.search-result-hover-button');
+    
+    match.el.empty();
+    
+    // Append our custom rendered content
+    match.el.appendChild(mountPoint);
+    
+    // Re-append the Link button if it exists (for unlinked mentions)
+    if (existingLinkButton) {
+      match.el.appendChild(existingLinkButton);
+    }
+    
+    // Re-append hover buttons if they exist
+    existingHoverButtons.forEach((button: Element) => {
+      match.el.appendChild(button);
+    });
   }
 }

--- a/src/ui/solid/plugin-context.tsx
+++ b/src/ui/solid/plugin-context.tsx
@@ -71,6 +71,7 @@ export function PluginContextProvider(props: PluginContextProps) {
       const target = event.target as HTMLElement;
       const previewLocation = {
         scroll: line,
+        line: line,
       };
       if (path) {
         props.plugin.app.workspace.trigger(


### PR DESCRIPTION
## Summary

This PR fixes an issue where the highlighted line in the page preview popup would be missing or incorrect when using **Better Search Views** alongside the **Hover Editor** plugin.

## The Issue

Currently, `handleMouseover` triggers the `link-hover` event with `previewLocation` set to `{ scroll: line }`.

While this works in some contexts, **Hover Editor** attempts to convert `scroll` to `line` in its `onLinkHover` handler. However, this conversion logic relies on the target element having the class `.search-result-file-match`, which Better Search Views does not use. Consequently, the preview fails to scroll to or highlight the correct line.

## Procedure to Reproduce

1. Install and enable both **Better Search Views** and **Hover Editor**.
    
2. Open a note that has **Linked Mentions** (Backlinks).
    
3. In the Linked Mentions view, hover over a specific result item (hold `Cmd` or `Ctrl` if your settings require it to trigger the preview).
    
4. **Current Behavior:** The Hover Editor window opens, but fails to highlight the specific line or scroll to the correct position.

## The Fix

I updated `plugin-context.tsx` to pass `{ line: line }` directly in the `EphemeralState` instead of using `scroll`.

```typescript
// Before
const previewLocation = {
  scroll: line,
};

// After
const previewLocation = {
  scroll: line,
  line: line,
};
```

## Demo

### Before

![before](https://github.com/user-attachments/assets/21cef896-aebb-4b9d-bb29-9bacc635bf64)

### After

![after](https://github.com/user-attachments/assets/ab4a419a-fc94-4cd8-8f69-783342774625)
